### PR TITLE
Update .tzapignore with .next

### DIFF
--- a/.tzapignore
+++ b/.tzapignore
@@ -24,3 +24,4 @@ build
 *generated*
 *actionpb*
 tfs.go
+.next


### PR DESCRIPTION
For nextJS projects, it is important to include .next to avoid indexing unnecessary files.