### PR TITLE
Update fileevaluator.go

### DIFF
--- a/cli/cmd/cmdutil/fileevaluator/fileevaluator.go
+++ b/cli/cmd/cmdutil/fileevaluator/fileevaluator.go
@@ -15,6 +15,7 @@ type FileEvaluator struct {
 const BaseTzapIgnore = `# Tzap ignore file. Add extra files like test folders, or other files that interfere with search (embeddings) quality.
 node_modules
 .env
+.next
 `
 
 const BaseTzapInclude = `# Common languages. Example, remove .js if .js files are only compiled bundles.


### PR DESCRIPTION
adding .next to avoid indexing unnecessary files in nextJS projects